### PR TITLE
Updating exception handling and return values (resolves #5)

### DIFF
--- a/R/py.call.R
+++ b/R/py.call.R
@@ -72,14 +72,16 @@ py.call <- function(fname, ...,
   rm(foo.args, foo.args.names)
 
   # execute function
-  on.exit(py.rm("_SnakeCharmR_return"))
-  py.exec(sprintf("_SnakeCharmR_return = json.dumps(%s(%s))", fname, foo.args.string))
+  py.exec(sprintf("_SnakeCharmR_return = json.dumps(%s(%s))", fname, foo.args.string),
+          stopOnException = TRUE)
   rm(foo.args.string)
 
   # get return value
   retval <- rcpp_Py_get_var("_SnakeCharmR_return")
   if (is.na(retval))
     stop("Cannot find function call return value")
+  else
+    py.rm("_SnakeCharmR_return")
 
   return(.py.fromJSON(retval, json.opt.ret))
 }

--- a/man/py.exec.Rd
+++ b/man/py.exec.Rd
@@ -10,13 +10,8 @@ py.exec(code, stopOnException = TRUE)
 \item{code}{a character vector containing Python code, typically a
 single line with indentation and EOL characters as required by Python syntax}
 
-\item{stopOnException}{logical value indicating whether or not to call \code{stop}
-if a Python exception occurs}
-}
-\value{
-if \code{stopOnException} is \code{FALSE}, returns a character vector of
-length 1 with a representation of any raised Python exceptions. Otherwise, returns 
-NULL invisibly.
+\item{stopOnException}{if \code{TRUE} then \code{stop} will be called if a 
+Python exception occurs, otherwise only a warning will be flagged}
 }
 \description{
 This function runs Python code that is provided in a character vector.
@@ -42,10 +37,9 @@ py.exec("raise Exception('Stop the presses!')")
 }
 
 py.exec("raise Exception('Houston, we have a problem!')", stopOnException = FALSE)
-# [1] "Exception('Houston, we have a problem!',)"
-
-str(py.exec("a = 'nothing to see here'"))
-#  NULL
+# Warning message:
+# In py.exec("raise Exception('Houston, we have a problem!')", stopOnException = FALSE) :
+#   Exception('Houston, we have a problem!',)
 }
 \keyword{manip}
 

--- a/man/py.rm.Rd
+++ b/man/py.rm.Rd
@@ -4,10 +4,14 @@
 \alias{py.rm}
 \title{Remove a Python variable from R}
 \usage{
-py.rm(var.name)
+py.rm(var.name, stopOnException = FALSE)
 }
 \arguments{
 \item{var.name}{a character string containing a valid Python variable name}
+
+\item{stopOnException}{if \code{TRUE} then \code{stop} will be called if a 
+Python exception occurs, typically because the variable doesn't exist, 
+otherwise only a warning will be flagged}
 }
 \description{
 This function uses the \code{del} Python command to remove a variable and reclaim
@@ -18,10 +22,11 @@ not exist, will be caught and ignored.
 py.assign("a", "foo bar")
 py.get("a")
 # [1] "foo bar"
+py.rm("a")
 \dontrun{
 py.rm("a")
-py.get("a")
-# Error in py.get("a") (from py.get.R#56) : NameError("name 'a' is not defined",)
+# Warning message:
+# In py.rm("a") : NameError("name 'a' is not defined",) 
 }
 }
 

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -30,3 +30,15 @@ test_that("calling Python function works", {
     list(1L, 2L, 3L)
   )
 })
+
+test_that("exception handling on calling Python function works", {
+  py.exec(
+    paste0(
+      "def raise_func():",
+      "    raise Exception('oh noes')",
+      collapse = "\n"
+    )
+  )
+  
+  expect_error(py.call("raise_func"), "oh noes")
+})

--- a/tests/testthat/test-exec.R
+++ b/tests/testthat/test-exec.R
@@ -1,0 +1,6 @@
+context("exec")
+
+test_that("exception handling on executing Python code works", {
+  expect_error(py.exec("raise Exception('oh noes')", stopOnException = TRUE), "oh noes")
+  expect_warning(py.exec("raise Exception('oh noes')", stopOnException = FALSE), "oh noes")
+})


### PR DESCRIPTION
- py.exec will now generate a warning if `stopOnException` is FALSE,
  and always return NULL;
- Updated `py.rm` to also generate a warning if an exception occurs;
- Added tests for exception handling in both py.exec and py.call.
