### PR TITLE
Adding stack traces to Python exceptions (#7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: r
 warnings_are_errors: true
 sudo: required
 
+os:
+  - linux
+  - osx
+
 apt_packages:
  - python-dev
  - python

--- a/R/py.exec.R
+++ b/R/py.exec.R
@@ -23,19 +23,23 @@
 #' 
 #' \dontrun{
 #' py.exec("raise Exception('Stop the presses!')")
-#' # Error in py.exec("raise Exception('Stop the presses!')") (from py.exec.R#41) : 
-#' #   Exception('Stop the presses!',)
+#' # Error in py.exec("raise Exception('Stop the presses!')") (from py.exec.R#48) : 
+#' #   Traceback (most recent call last):
+#' #   File "<string>", line 2, in <module>
+#' # Exception: Stop the presses!
 #' }
 #' 
 #' py.exec("raise Exception('Houston, we have a problem!')", stopOnException = FALSE)
 #' # Warning message:
 #' # In py.exec("raise Exception('Houston, we have a problem!')", stopOnException = FALSE) :
-#' #   Exception('Houston, we have a problem!',)
+#' #   Traceback (most recent call last):
+#' #   File "<string>", line 2, in <module>
+#' # Exception: Houston, we have a problem!
 py.exec <- function(code, stopOnException = TRUE) {
   # execute code with exception handling
   rcpp_Py_run_code(
     sprintf(
-      "try:\n%s\nexcept BaseException as e:\n    _SnakeCharmR_exception = json.dumps(repr(e))",
+      "try:\n%s\nexcept:\n    _SnakeCharmR_exception = traceback.format_exc()",
       paste0("    ", unlist(sapply(code, stringr::str_split, "\n|\r\n"), use.names = F),
              collapse = "\n")
     )
@@ -45,7 +49,6 @@ py.exec <- function(code, stopOnException = TRUE) {
   exception = rcpp_Py_get_var("_SnakeCharmR_exception")
   if (!is.na(exception)) {
     py.rm("_SnakeCharmR_exception")
-    exception = .py.fromJSON(exception)
     if (stopOnException)
       stop(exception)
     else

--- a/R/py.get.R
+++ b/R/py.get.R
@@ -29,7 +29,9 @@
 #' \dontrun{
 #' py.rm("notset")
 #' py.get("notset")
-#' # Error in py.get("notset") (from py.get.R#56) : NameError("name 'notset' is not defined",)
+#' # Error in py.get("notset") (from py.get.R#60) : Traceback (most recent call last):
+#' #   File "<string>", line 2, in <module>
+#' # NameError: name 'notset' is not defined
 #' }
 py.get <- function(var.name, json.opt.ret = getOption("SnakeCharmR.json.opt.ret", list())) {
   # parameter validation
@@ -40,7 +42,7 @@ py.get <- function(var.name, json.opt.ret = getOption("SnakeCharmR.json.opt.ret"
 
   # get variable value
   rcpp_Py_run_code(
-    sprintf("try:\n    _SnakeCharmR_return = json.dumps(%s)\nexcept BaseException as e:\n    _SnakeCharmR_exception = json.dumps(repr(e))", 
+    sprintf("try:\n    _SnakeCharmR_return = json.dumps(%s)\nexcept:\n    _SnakeCharmR_exception = traceback.format_exc()", 
             var.name)
   )
 
@@ -54,11 +56,9 @@ py.get <- function(var.name, json.opt.ret = getOption("SnakeCharmR.json.opt.ret"
   # value does not exist, stop with the exception value
   exception = rcpp_Py_get_var("_SnakeCharmR_exception")
   if (is.na(exception))
-    stop(
-      sprintf("Unexpected error reading %s, JSON encoded return value nor exception exist",
-              var.name)
-    )
+    stop(sprintf("Unexpected error reading %s, JSON encoded return value nor exception exist",
+                 var.name))
   py.rm("_SnakeCharmR_exception")
-  stop(.py.fromJSON(exception))
+  stop(exception)
 }
 

--- a/R/py.rm.R
+++ b/R/py.rm.R
@@ -17,7 +17,9 @@
 #' \dontrun{
 #' py.rm("a")
 #' # Warning message:
-#' # In py.rm("a") : NameError("name 'a' is not defined",) 
+#' # In py.rm("a") : Traceback (most recent call last):
+#' #   File "<string>", line 2, in <module>
+#' # NameError: name 'a' is not defined
 #' }
 py.rm <- function(var.name, stopOnException = FALSE) {
   # parameter validation
@@ -25,17 +27,14 @@ py.rm <- function(var.name, stopOnException = FALSE) {
     stop("Bad or missing var.name parameter")
 
   rcpp_Py_run_code(
-    sprintf(
-      "try:\n    del %s\nexcept BaseException as e:\n    _SnakeCharmR_exception = json.dumps(repr(e))",
-      var.name
-    )
+    sprintf("try:\n    del %s\nexcept:\n    _SnakeCharmR_exception = traceback.format_exc()",
+            var.name)
   )
   
   # try to read the stored exception
   exception = rcpp_Py_get_var("_SnakeCharmR_exception")
   if (!is.na(exception)) {
     rcpp_Py_run_code("del _SnakeCharmR_exception")
-    exception = .py.fromJSON(exception)
     if (stopOnException)
       stop(exception)
     else

--- a/man/py.exec.Rd
+++ b/man/py.exec.Rd
@@ -32,14 +32,18 @@ py.call("concat", a, b)
 
 \dontrun{
 py.exec("raise Exception('Stop the presses!')")
-# Error in py.exec("raise Exception('Stop the presses!')") (from py.exec.R#41) : 
-#   Exception('Stop the presses!',)
+# Error in py.exec("raise Exception('Stop the presses!')") (from py.exec.R#48) : 
+#   Traceback (most recent call last):
+#   File "<string>", line 2, in <module>
+# Exception: Stop the presses!
 }
 
 py.exec("raise Exception('Houston, we have a problem!')", stopOnException = FALSE)
 # Warning message:
 # In py.exec("raise Exception('Houston, we have a problem!')", stopOnException = FALSE) :
-#   Exception('Houston, we have a problem!',)
+#   Traceback (most recent call last):
+#   File "<string>", line 2, in <module>
+# Exception: Houston, we have a problem!
 }
 \keyword{manip}
 

--- a/man/py.get.Rd
+++ b/man/py.get.Rd
@@ -40,7 +40,9 @@ py.get("math.pi")
 \dontrun{
 py.rm("notset")
 py.get("notset")
-# Error in py.get("notset") (from py.get.R#56) : NameError("name 'notset' is not defined",)
+# Error in py.get("notset") (from py.get.R#60) : Traceback (most recent call last):
+#   File "<string>", line 2, in <module>
+# NameError: name 'notset' is not defined
 }
 }
 

--- a/man/py.rm.Rd
+++ b/man/py.rm.Rd
@@ -26,7 +26,9 @@ py.rm("a")
 \dontrun{
 py.rm("a")
 # Warning message:
-# In py.rm("a") : NameError("name 'a' is not defined",) 
+# In py.rm("a") : Traceback (most recent call last):
+#   File "<string>", line 2, in <module>
+# NameError: name 'a' is not defined
 }
 }
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -19,6 +19,7 @@ void rcpp_Py_Initialize() {
 
   Py_Initialize();
   PyRun_SimpleString("import json");
+  PyRun_SimpleString("import traceback");
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
- Using Python module `traceback` to capture exception and its stack
  trace as a string;
- Adding OS X as to Travis tests.
