### PR TITLE
Fix handling of NULL in arguments (resolves #9)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: SnakeCharmR
-Version: 1.0.0
+Version: 1.0.1
 Date: 2016-05-20
 Title: R and Python Integration
 Author: Alexandre Sieira, forked off of rPython by Carlos J. Gil Bellosta

--- a/R/misc.R
+++ b/R/misc.R
@@ -1,6 +1,6 @@
 .onAttach <- function(libname, pkgname) {
   packageStartupMessage(
-    c("SnakeCharmR v1.0.0 - R and Python Integration\n",
+    c("SnakeCharmR v1.0.1 - R and Python Integration\n",
       "Contribute and submit issues at https://github.com/asieira/SnakeCharmR")
   )
 }
@@ -14,11 +14,12 @@
 }
 
 .py.toJSON <- function(x, json.options = list()) {
-  json.options$x <- x
+  if (is.null(x))
+    return("None")
   paste0(
     "json.loads('''",
     str_replace_all(
-      do.call(toJSON, json.options),
+      do.call(toJSON, c(json.options, list(x = x))),
       regex("(['\\\\])"),
       "\\\\\\1"
     ),
@@ -27,6 +28,5 @@
 }
 
 .py.fromJSON <- function(x, json.options = list()) {
-  json.options$txt = x
-  do.call(fromJSON, json.options)
+  do.call(fromJSON, c(json.options, list(txt = x)))
 }

--- a/R/py.assign.R
+++ b/R/py.assign.R
@@ -42,7 +42,7 @@
 #' # [1] "[u'foo bar']"
 py.assign <- function(var.name, value,
                       json.opt.args = getOption("SnakeCharmR.json.opt.args", 
-                                                list(auto_unbox = TRUE))) {
+                                                list(auto_unbox = TRUE, null = "null"))) {
   # input validation
   if (missing(var.name) || !is.character(var.name) || is.na(var.name) || length(var.name) != 1)
     stop("Bad or missing var.name parameter")

--- a/R/py.call.R
+++ b/R/py.call.R
@@ -44,8 +44,10 @@
 #' py.call("repr", "foo bar", json.opt.args = list(auto_unbox = FALSE))
 #' # [1] "[u'foo bar']"
 py.call <- function(fname, ...,
-                    json.opt.args = getOption("SnakeCharmR.json.opt.args", list(auto_unbox = TRUE)),
-                    json.opt.ret = getOption("SnakeCharmR.json.opt.ret", list())) {
+                    json.opt.args = getOption("SnakeCharmR.json.opt.args", 
+                                              list(auto_unbox = TRUE, null = "null")),
+                    json.opt.ret = getOption("SnakeCharmR.json.opt.ret", 
+                                             list())) {
   if (missing(fname) || !is.character(fname) || is.na(fname) || length(fname) != 1)
     stop("Bad or missing fname parameter")
 

--- a/man/py.assign.Rd
+++ b/man/py.assign.Rd
@@ -6,7 +6,7 @@
 \usage{
 py.assign(var.name, value,
   json.opt.args = getOption("SnakeCharmR.json.opt.args", list(auto_unbox =
-  TRUE)))
+  TRUE, null = "null")))
 }
 \arguments{
 \item{var.name}{a character string containing a valid Python variable name}

--- a/man/py.call.Rd
+++ b/man/py.call.Rd
@@ -5,7 +5,7 @@
 \title{Calls Python functions and methods from R}
 \usage{
 py.call(fname, ..., json.opt.args = getOption("SnakeCharmR.json.opt.args",
-  list(auto_unbox = TRUE)),
+  list(auto_unbox = TRUE, null = "null")),
   json.opt.ret = getOption("SnakeCharmR.json.opt.ret", list()))
 }
 \arguments{

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -29,6 +29,10 @@ test_that("calling Python function works", {
             json.opt.ret = list(simplifyVector = FALSE)),
     list(1L, 2L, 3L)
   )
+  expect_equal(
+    py.call("repr", NULL),
+    "None"
+  )
 })
 
 test_that("exception handling on calling Python function works", {

--- a/tests/testthat/test-get-assign.R
+++ b/tests/testthat/test-get-assign.R
@@ -10,4 +10,6 @@ test_that("strings are preserved", {
   expect_equal(assign_and_get("\\"), "\\")
   expect_equal(assign_and_get("áéíóú"), "áéíóú")
   expect_equal(assign_and_get("'áéíóú\\'"), "'áéíóú\\'")
+  expect_equal(assign_and_get(NULL), NULL)
+  expect_equal(assign_and_get(list(a = NULL)), list(a = NULL))
 })


### PR DESCRIPTION
- Implemented workaround to unexpected behavior from
  `jsonlite::toJSON(NULL, null = “null”)` in .py.toJSON;
- Updated default options passed to jsonlite::toJSON to include `null =
  “null”`;
- Bumped version to 1.0.1.
