### PR TITLE
Better handling of encoding (resolves #20)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SnakeCharmR
-Version: 1.0.2
-Date: 2016-05-20
+Version: 1.0.3
+Date: 2016-05-29
 Title: R and Python Integration
 Author: Alexandre Sieira, forked off of rPython by Carlos J. Gil Bellosta
 Maintainer: Alexandre Sieira <alexandre.sieira@gmail.com>

--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -10,6 +10,14 @@ knitr::opts_chunk$set(
   fig.retina = 2
 )
 ```
+# SnakeCharmR 1.0.3
+
+Taking measures to ensure SnakeCharmR will work properly on systems where the native encoding is not UTF-8:
+
+* Using Python API to check if variable is str/bytes or unicode and handling things correctly. In particular, when we read Python unicode values we flag the resulting R string as UTF-8 since that’s what we Python C API we are using will return;
+
+* Ensuring that Python code being executed is converted to UTF-8 and that the Python interpreter is made aware of that according to PEP 263.
+
 # SnakeCharmR 1.0.2
 
 Fixed linking and building errors on some platforms (such as Amazon Linux) by updating the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 
 <!-- NEWS.md is generated from NEWS.Rmd. Please edit that file -->
+SnakeCharmR 1.0.3
+=================
+
+Taking measures to ensure SnakeCharmR will work properly on systems where the native encoding is not UTF-8:
+
+-   Using Python API to check if variable is str/bytes or unicode and handling things correctly. In particular, when we read Python unicode values we flag the resulting R string as UTF-8 since that’s what we Python C API we are using will return;
+
+-   Ensuring that Python code being executed is converted to UTF-8 and that the Python interpreter is made aware of that according to PEP 263.
+
 SnakeCharmR 1.0.2
 =================
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -1,6 +1,6 @@
 .onAttach <- function(libname, pkgname) {
   packageStartupMessage(
-    c("SnakeCharmR v1.0.2 - R and Python Integration\n",
+    c("SnakeCharmR v1.0.3 - R and Python Integration\n",
       "Contribute and submit issues at https://github.com/asieira/SnakeCharmR")
   )
 }

--- a/tests/testthat/test-rcpp-get.R
+++ b/tests/testthat/test-rcpp-get.R
@@ -1,0 +1,15 @@
+# context("Rcpp get of string/bytes and unicode types")
+# 
+# test_that("we can read string//bytes and unicode", {
+#   py.exec("_test_var = 'blah'")
+#   expect_equal(rcpp_Py_get_var("_test_var"), "blah")
+# 
+#   py.exec("_test_var = u'blah'")
+#   expect_equal(rcpp_Py_get_var("_test_var"), "blah")
+#   
+#   py.exec("_test_var = u'áéíóú'")
+#   expect_equal(rcpp_Py_get_var("_test_var"), "áéíóú")
+#   
+#   py.exec("_test_var = 1")
+#   expect_error(rcpp_Py_get_var("_test_var"), "variable is not a string")
+# })


### PR DESCRIPTION
- Using Python API to check if variable is str/bytes or unicode and handling things correctly. In particular, when we read Python unicode values we flag the resulting R string as UTF-8 since that’s what we Python C API we are using will return;
- Ensuring that Python code being executed is converted to UTF-8 and that the Python interpreter is made aware of that according to [PEP 263](https://www.python.org/dev/peps/pep-0263/);
- Updated version to 1.0.3.
