### PR TITLE
Make Windows compile work;  Should fix Issue #13

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ Imports:
 License: GPL-2
 SystemRequirements: Python (>= 2.7) and Python headers and libraries
     (See the INSTALL file)
-OS_type: unix
 URL: https://github.com/asieira/SnakeCharmR
 BugReports: https://github.com/asieira/SnakeCharmR/issues
 Suggests:

--- a/configure.win
+++ b/configure.win
@@ -2,4 +2,5 @@
 
 echo 'PKG_LIBS=-LC:/python27/libs -lpython27'  > src/makevars.win
 echo 'PKG_CFLAGS=-I"C:/Python27/include"'     >> src/makevars.win
+echo 'PKG_CPPFLAGS=-I"C:/Python27/include"'     >> src/makevars.win
 


### PR DESCRIPTION
Its not too hard to make this compile on windows.  I tested under windows using python 2.7 installed in the standard location, and then run the testthat packages using `test()`.  This gives:


```
> test()
Loading SnakeCharmR
Loading required package: testthat
SnakeCharmR 1.0.6 - R and Python Integration
Contribute and submit issues at https://github.com/asieira/SnakeCharmR

Python version 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 20:42:59) [MSC v.1500 32 bit (Intel)]
Testing SnakeCharmR
call: ......
exec: ..
assign and get: ......

DONE ===========================================================================
Warning message:
package 'testthat' was built under R version 3.2.5 
> 
```